### PR TITLE
Add quiz route using OpenAI, solved.ac, frontend page

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -1,3 +1,5 @@
+require('dotenv').config({ path: require('path').resolve(__dirname, '../.env') });
+
 const cors = require('cors');
 const express = require('express');
 const session = require('express-session');
@@ -18,7 +20,7 @@ const levelRoutes = require('./routes/levelRoutes');
 const analysisRoutes = require('./routes/analysisRoutes');
 const levelTestRoutes = require('./routes/levelTest');
 
-
+const quizRoutes = require('./routes/quiz');
 
 const app = express();
 initPassport();
@@ -56,7 +58,7 @@ app.use('/api/results', resultRoutes);
 app.use('/api/level', levelRoutes);
 app.use('/api/analysis', analysisRoutes);
 
-
+app.use('/api/quiz', quizRoutes);
 
 app.get('/', (req, res) => res.sendFile(path.join(__dirname, 'public/index.html')));
 

--- a/backend/auth/passport.js
+++ b/backend/auth/passport.js
@@ -9,6 +9,14 @@ const bcrypt = require('bcryptjs');
 const { Op } = require('sequelize');
 
 module.exports = () => {
+  
+  //테스트하려고 잠깐 수정
+  const { GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_CALLBACK_URL } = process.env;
+  if (!GOOGLE_CLIENT_ID || !GOOGLE_CLIENT_SECRET || !GOOGLE_CALLBACK_URL) {
+    console.warn('[auth] Google OAuth disabled: missing GOOGLE_* env. Skipping passport-google-oauth20.');
+    return;
+  }
+
   passport.serializeUser((user, done) => {
     done(null, user.user_id);
   });

--- a/backend/routes/quiz.js
+++ b/backend/routes/quiz.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const express = require('express');
+const router = express.Router();
+const { getUserTier, searchProblemsByTier } = require('../services/solvedac');
+const { makeCloze, computeBlankConfig } = require('../services/openaiCloze');
+
+router.get('/next', async (req, res) => {
+  try {
+    const handle = String(req.query.handle || '');
+    if (!handle) return res.status(400).json({ error: 'handle required' });
+    const language = String(req.query.lang || 'python').toLowerCase();
+    const tags = String(req.query.tags || '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+    const tier = (await getUserTier(handle).catch(() => null)) ?? 8;
+    const tierMin = Math.max(1, tier - 2);
+    const tierMax = Math.min(30, tier + 2);
+
+    const probs = await searchProblemsByTier({ tierMin, tierMax, tags, page: 1 });
+    if (!probs?.length) return res.status(404).json({ error: 'no problems for tier range', tierMin, tierMax });
+
+    const problem = probs[Math.floor(Math.random() * probs.length)];
+
+    const { blanks, depth } = computeBlankConfig({ tier, prevAcc: 0.6 });
+
+    const cloze = await makeCloze({ problem, language, tags, tier, prevAcc: 0.6 });
+
+    return res.json({
+      user: { handle, tier, range: `${tierMin}..${tierMax}` },
+      problem: { id: problem.problemId, title: problem.titleKo, level: problem.level },
+      blankConfig: { requested: { blanks, depth }, actual: { blanks: cloze.blanksCount, depth: cloze.depth } },
+      code: cloze.code,
+      blanks: cloze.blanks.map(({ id, hint }) => ({ id, hint })), 
+    });
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: 'internal_error', detail: String(e.message || e) });
+  }
+});
+
+module.exports = router;

--- a/backend/scripts/checkApis.js
+++ b/backend/scripts/checkApis.js
@@ -1,0 +1,59 @@
+const path = require('path');
+
+require('dotenv').config({ path: path.resolve(__dirname, '../../.env') });
+
+(async () => {
+  let _fetch = global.fetch;
+  if (!_fetch) {
+    _fetch = (await import('node-fetch')).default;
+  }
+  const fetch = (...args) => _fetch(...args);
+
+  const key = process.env.OPENAI_API_KEY || '';
+  console.log('OPENAI_API_KEY:', key ? key.slice(0, 7) + '...' : '(missing)');
+  console.log('OPENAI_MODEL :', process.env.OPENAI_MODEL || '(default gpt-4o-mini)');
+  console.log('SOLVEDAC_BASE:', process.env.SOLVEDAC_BASE || '(default https://solved.ac/api/v3)');
+  console.log('Node version :', process.version);
+
+  async function checkSolvedAc(handle = 'koosaga') {
+    const base = process.env.SOLVEDAC_BASE || 'https://solved.ac/api/v3';
+    const url = `${base}/user/show?handle=${encodeURIComponent(handle)}`;
+    const res = await fetch(url, { headers: { 'User-Agent': 'gpters-check/1.0' } });
+    const text = await res.text();
+    console.log('\n[solved.ac] status:', res.status);
+    if (!res.ok) throw new Error(text);
+    try {
+      const j = JSON.parse(text);
+      console.log('[solved.ac] sample:', { handle: j.handle, tier: j.tier, solvedCount: j.solvedCount });
+    } catch (e) {
+      console.log('[solved.ac] JSON parse err:', e.message, 'body:', text.slice(0, 200));
+    }
+  }
+
+  async function checkOpenAI() {
+    if (!process.env.OPENAI_API_KEY) {
+      console.warn('\n[openai] OPENAI_API_KEY missing → skip test'); return;
+    }
+    const body = {
+      model: process.env.OPENAI_MODEL || 'gpt-4o-mini',
+      messages: [{ role: 'user', content: 'Return only: OK' }],
+      max_tokens: 4,
+      temperature: 0
+    };
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`
+      },
+      body: JSON.stringify(body)
+    });
+    const data = await res.json().catch(async () => ({ raw: await res.text() }));
+    console.log('\n[openai] status:', res.status);
+    console.log('[openai] sample:', data?.choices?.[0]?.message?.content ?? data);
+  }
+
+  const handle = process.argv[2] || 'koosaga';
+  try { await checkSolvedAc(handle); } catch (e) { console.error('[solved.ac] error:', e.message); }
+  try { await checkOpenAI(); } catch (e) { console.error('[openai] error:', e.message); }
+})();

--- a/backend/services/openaiCloze.js
+++ b/backend/services/openaiCloze.js
@@ -1,0 +1,75 @@
+'use strict';
+
+if (!global.fetch) {
+  global.fetch = (...args) => import('node-fetch').then(({ default: f }) => f(...args));
+}
+
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+const OPENAI_MODEL = process.env.OPENAI_MODEL || 'gpt-4o-mini';
+
+function computeBlankConfig({ tier = 8, prevAcc = 0.6 }) {
+  const base = tier <= 8 ? 2 : tier <= 12 ? 3 : tier <= 16 ? 4 : 5;
+  let blanks = base;
+  let depth = 'shallow';
+  if (prevAcc >= 0.8) { blanks += 1; depth = 'mixed'; }
+  if (prevAcc >= 0.9) { blanks += 1; depth = 'deep'; }
+  if (prevAcc < 0.5) { blanks = Math.max(2, base - 1); depth = 'shallow'; }
+  return { blanks, depth };
+}
+
+async function makeCloze({ problem, language = 'python', tags = [], tier = 8, prevAcc = 0.6 }) {
+  if (!OPENAI_API_KEY) throw new Error('OPENAI_API_KEY missing');
+  const { blanks, depth } = computeBlankConfig({ tier, prevAcc });
+
+  const system =
+    'You are an algorithm tutor. Create a fill-in-the-blank coding exercise. ' +
+    'Return STRICT JSON with keys: code, blanks. ' +
+    'code: the source with placeholders like /* __1__ */, /* __2__ */. ' +
+    'blanks: array of { id, answer, hint }. ' +
+    'Do NOT include markdown. Keep code self-contained and runnable. ' +
+    'Do NOT quote or reproduce any original problem statement; abstract the task.';
+
+  const user = JSON.stringify({
+    instruction: 'Generate a single-file solution; include minimal I/O or function stub.',
+    language,
+    blanks,
+    depth,
+    problem: {
+      id: problem?.problemId,
+      title: problem?.titleKo,
+      url: problem?.problemId ? `https://www.acmicpc.net/problem/${problem.problemId}` : '',
+      tags,
+    },
+  });
+
+  const body = {
+    model: OPENAI_MODEL,
+    messages: [
+      { role: 'system', content: system },
+      { role: 'user', content: user },
+    ],
+    temperature: 0.2,
+    response_format: { type: 'json_object' },
+  };
+
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${OPENAI_API_KEY}` },
+    body: JSON.stringify(body),
+  });
+
+  const text = await res.text();
+  if (!res.ok) throw new Error(`OpenAI ${res.status}\n${text}`);
+  let parsed;
+  try {
+    parsed = JSON.parse(JSON.parse(text)?.choices?.[0]?.message?.content || '{}');
+  } catch {
+    throw new Error(`Invalid JSON from model\n${text.slice(0, 200)}`);
+  }
+  if (!parsed?.code || !Array.isArray(parsed?.blanks)) {
+    throw new Error('Malformed cloze payload (missing code/blanks)');
+  }
+  return { ...parsed, blanksCount: parsed.blanks.length, depth };
+}
+
+module.exports = { computeBlankConfig, makeCloze };

--- a/backend/services/solvedac.js
+++ b/backend/services/solvedac.js
@@ -1,0 +1,38 @@
+'use strict';
+
+if (!global.fetch) {
+  global.fetch = (...args) => import('node-fetch').then(({ default: f }) => f(...args));
+}
+
+const BASE = process.env.SOLVEDAC_BASE || 'https://solved.ac/api/v3';
+
+async function _json(url) {
+  const res = await fetch(url, { headers: { 'User-Agent': 'gpters/1.0 (quiz-lite)' } });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`solved.ac ${res.status} ${url}\n${text}`);
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`solved.ac JSON parse error\n${text.slice(0, 200)}`);
+  }
+}
+
+async function getUserTier(handle) {
+  const j = await _json(`${BASE}/user/show?handle=${encodeURIComponent(handle)}`);
+  return j?.tier ?? null;
+}
+
+async function searchProblemsByTier({ tierMin, tierMax, tags = [], page = 1 }) {
+  const tagQ = tags.map((t) => `tag:${t}`).join(' ');
+  const query = `tier:${tierMin}..${tierMax} ${tagQ}`.trim();
+  const j = await _json(`${BASE}/search/problem?query=${encodeURIComponent(query)}&page=${page}`);
+  const items = j?.items ?? [];
+  return items.map((p) => ({
+    problemId: p.problemId ?? p.id,
+    titleKo: p.titleKo ?? p.title ?? '',
+    level: p.level ?? p.tier ?? null,
+    tags: (p.tags ?? p.tagIds ?? []).map((t) => t?.key ?? t?.displayNames?.ko ?? String(t)),
+  }));
+}
+
+module.exports = { getUserTier, searchProblemsByTier };

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,8 @@ import ProfilePage from './pages/ProfilePage'
 import SurveyPage from './pages/SurveyPage'
 import LevelTestPage from './pages/LevelTestPage'
 
+import QuizPage from './pages/QuizPage'
+
 function App() {
   return (
     <AuthProvider>
@@ -21,6 +23,7 @@ function App() {
             <Route path="/profile" element={<ProfilePage />} />
             <Route path="/survey" element={<SurveyPage />} />
             <Route path="/level-test" element={<LevelTestPage />} />
+            <Route path="/quiz" element={<QuizPage />} />
           </Routes>
         </main>
       </div>

--- a/frontend/src/pages/QuizPage.tsx
+++ b/frontend/src/pages/QuizPage.tsx
@@ -1,0 +1,169 @@
+import React, { useMemo, useState } from "react";
+
+type BlankWire = { id: number | string; hint?: string };
+type NextResp = {
+  user?: { handle?: string; tier?: number; range?: string };
+  problem?: { id?: number; title?: string; level?: number; url?: string };
+  blankConfig?: any;
+  code: string;
+  blanks?: BlankWire[];
+};
+
+type Blank = { id: number; hint?: string };
+
+function normalizeBlankId(id: number | string): number | null {
+  if (typeof id === "number" && Number.isFinite(id)) return id;
+  if (typeof id === "string") {
+    const m = id.match(/(\d+)/);
+    if (m) return parseInt(m[1], 10);
+  }
+  return null;
+}
+
+function extractPlaceholderIdsFromCode(code: string): number[] {
+  const ids = new Set<number>();
+  for (const m of code.matchAll(/\/\*\s*__\s*(\d+)\s*__\s*\*\//g)) ids.add(parseInt(m[1], 10));
+  for (const m of code.matchAll(/\/\/\s*__\s*(\d+)\s*__/g)) ids.add(parseInt(m[1], 10));
+  for (const m of code.matchAll(/#\s*__\s*(\d+)\s*__/g)) ids.add(parseInt(m[1], 10));
+  for (const m of code.matchAll(/__\s*(\d+)\s*__/g)) ids.add(parseInt(m[1], 10));
+  return Array.from(ids).sort((a, b) => a - b);
+}
+
+function prettify(code: string): string {
+  return code
+    .replace(/\/\*\s*__\s*(\d+)\s*__\s*\*\//g, "[__$1__]")
+    .replace(/\/\/\s*__\s*(\d+)\s*__/g, "[__$1__]")
+    .replace(/#\s*__\s*(\d+)\s*__/g, "[__$1__]")
+    .replace(/__\s*(\d+)\s*__/g, "[__$1__]");
+}
+
+export default function QuizPage() {
+  const [handle, setHandle] = useState("");
+  const [lang, setLang] = useState<"python" | "javascript" | "java">("python");
+  const [tags, setTags] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const [resp, setResp] = useState<NextResp | null>(null);
+  const [blanks, setBlanks] = useState<Blank[]>([]);
+
+  const prettyCode = useMemo(() => (resp?.code ? prettify(resp.code) : ""), [resp?.code]);
+
+  async function fetchNext() {
+    if (!handle.trim()) {
+      alert("solved.ac 핸들을 입력해 주세요.");
+      return;
+    }
+    setLoading(true);
+    try {
+      const qs = new URLSearchParams({
+        handle,
+        lang,
+        ...(tags.trim() ? { tags } : {}),
+      }).toString();
+
+      const r = await fetch(`/api/quiz/next?${qs}`);
+      const j: NextResp = await r.json();
+      if (!r.ok) throw new Error(typeof j === "string" ? j : "요청 실패");
+
+      let normalized: Blank[] = [];
+      if (j.blanks?.length) {
+        normalized = j.blanks
+          .map((b) => {
+            const id = normalizeBlankId(b.id);
+            return id ? { id, hint: b.hint } : null;
+          })
+          .filter(Boolean) as Blank[];
+      }
+      
+      if (normalized.length === 0) {
+        normalized = extractPlaceholderIdsFromCode(j.code).map((id) => ({ id }));
+      }
+
+      setResp(j);
+      setBlanks(normalized);
+    } catch (e: any) {
+      alert(e?.message ?? "문제 불러오기 실패");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div style={{ maxWidth: 960, margin: "24px auto", padding: 16 }}>
+      <h2>알고리즘 문제 불러오기</h2>
+
+      <div style={{ display: "flex", gap: 8, margin: "12px 0", flexWrap: "wrap" }}>
+        <input
+          placeholder="solved.ac 핸들"
+          value={handle}
+          onChange={(e) => setHandle(e.target.value)}
+          style={{ padding: 8, minWidth: 220 }}
+        />
+        <select value={lang} onChange={(e) => setLang(e.target.value as any)} style={{ padding: 8 }}>
+          <option value="python">Python</option>
+          <option value="javascript">JavaScript</option>
+          <option value="java">Java</option>
+        </select>
+        <input
+          placeholder="태그(선택, 예: dp,graph)"
+          value={tags}
+          onChange={(e) => setTags(e.target.value)}
+          style={{ padding: 8, minWidth: 220 }}
+        />
+        <button onClick={fetchNext} disabled={loading || !handle.trim()}>
+          {loading ? "불러오는 중..." : "문제 받기"}
+        </button>
+      </div>
+
+      {resp && (
+        <div style={{ display: "grid", gap: 12 }}>
+          {}
+          <div style={{ fontSize: 14, color: "#555" }}>
+            {resp.problem?.title ?? "문제"}{" "}
+            {resp.problem?.level ? `(lvl ${resp.problem.level})` : ""}
+            {resp.problem?.url ? (
+              <>
+                {" · "}
+                <a href={resp.problem.url} target="_blank" rel="noreferrer">
+                  원문
+                </a>
+              </>
+            ) : null}
+            {resp.user?.handle ? (
+              <span style={{ float: "right", opacity: 0.75 }}>
+                @{resp.user.handle} · tier {resp.user.tier ?? "-"} · {resp.user.range ?? ""}
+              </span>
+            ) : null}
+          </div>
+
+          {}
+          <pre
+            style={{
+              background: "#0b1020",
+              color: "#e6e6e6",
+              padding: 12,
+              borderRadius: 8,
+              whiteSpace: "pre-wrap",
+              overflowX: "auto",
+            }}
+          >
+            <code>{prettyCode}</code>
+          </pre>
+
+          {}
+          <div style={{ border: "1px solid #eee", borderRadius: 8, padding: 12 }}>
+            <b>힌트</b>
+            <ul style={{ marginTop: 8 }}>
+              {blanks.map((b) => (
+                <li key={b.id}>
+                  #{b.id} {b.hint ? `: ${b.hint}` : ""}
+                </li>
+              ))}
+            </ul>
+            {!blanks.length && <div style={{ color: "#777" }}>표시할 빈칸이 없습니다.</div>}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,6 +5,7 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   server: {
+    port: 5173,
     proxy: {
       '/api': {
         target: 'http://localhost:3001',


### PR DESCRIPTION
feat(quiz) : 퀴즈 생성 API + front 연동 (OpenAI + solved.ac)

backend
- routes : GET /api/quiz/next route 추가 (DB 없이 퀴즈 생성만)
- services/openaiCloze.js : OpenAI Chat Completions로 빈칸 있는 코드 생성, 난이도(빈칸 수/깊이) 계산
- app.js : /api/quiz route
- auth/passport.js : 에러 때문에 미설정 시 Google OAuth 비활성 코드 추가
- scripts/checkApis.js : OpenAI, solved.ac 연결 상태 테스트용

frontend
- App.tsx : /quiz route 추가