### PR TITLE
feat(solve/quiz/dashboard)

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -20,6 +20,8 @@ const levelTestRoutes = require('./routes/levelTest');
 
 const quizRoutes = require('./routes/quiz');
 const problemBankRoutes = require('./routes/problemBank');
+const analyticsRoutes = require('./routes/analytics');
+const solveRoutes = require('./routes/solve');
 
 const app = express();
 initPassport();
@@ -74,6 +76,8 @@ app.use('/api/analysis', analysisRoutes);
 
 app.use('/api/quiz', quizRoutes);
 app.use('/api/problem-bank', problemBankRoutes);
+app.use('/api/analytics', analyticsRoutes);
+app.use('/api/solve', solveRoutes);
 
 // API 전용 백엔드 - HTML 라우트 제거됨
 

--- a/backend/migrations/add_user_id_to_study_sessions.sql
+++ b/backend/migrations/add_user_id_to_study_sessions.sql
@@ -1,0 +1,13 @@
+-- study_sessions 테이블에 user_id 컬럼 추가
+ALTER TABLE study_sessions 
+ADD COLUMN user_id VARCHAR(128) NULL 
+AFTER id;
+
+-- 기존 데이터에 대한 인덱스 추가 (성능 최적화)
+CREATE INDEX idx_study_sessions_user_id ON study_sessions(user_id);
+CREATE INDEX idx_study_sessions_client_id ON study_sessions(client_id);
+
+-- 기존 handle 기본값 'anonymous'로 설정된 레코드들을 위한 체크
+UPDATE study_sessions 
+SET handle = 'anonymous' 
+WHERE handle IS NULL OR handle = '';

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -28,6 +28,7 @@ db.Submission = require('./submission')(sequelize, DataTypes);
 db.Statistics = require('./statistics')(sequelize, DataTypes);
 
 db.ProblemBank = require('./problem_bank.model')(sequelize, Sequelize.DataTypes);
+db.StudySession = require('./study_session.model')(sequelize, Sequelize.DataTypes);
 
 // ✅ 모델 관계 설정
 if (db.User.associate) db.User.associate(db);

--- a/backend/models/study_session.model.js
+++ b/backend/models/study_session.model.js
@@ -1,0 +1,26 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  const StudySession = sequelize.define('StudySession', {
+    id: { type: DataTypes.BIGINT, primaryKey: true, autoIncrement: true },
+    user_id: { type: DataTypes.STRING(128), allowNull: true },   // 로그인된 사용자 ID
+    handle: { type: DataTypes.STRING(64), allowNull: false },
+    client_id: { type: DataTypes.STRING(64), allowNull: true },   // ✅ 추가
+    language: { type: DataTypes.STRING(32), allowNull: false },
+    topic: { type: DataTypes.STRING(64), allowNull: false },
+    level: { type: DataTypes.INTEGER, allowNull: false },
+    source: { type: DataTypes.ENUM('bank', 'quiz'), allowNull: false, defaultValue: 'bank' },
+    problem_id: { type: DataTypes.BIGINT, allowNull: true },
+    started_at: { type: DataTypes.DATE, allowNull: false, defaultValue: DataTypes.NOW },
+    finished_at: { type: DataTypes.DATE, allowNull: true },
+    duration_ms: { type: DataTypes.INTEGER, allowNull: true },
+    blanks_total: { type: DataTypes.INTEGER, allowNull: false },
+    blanks_correct: { type: DataTypes.INTEGER, allowNull: false },
+    accuracy: { type: DataTypes.DECIMAL(5,2), allowNull: true },
+    blanks_detail: { type: DataTypes.JSON, allowNull: false }
+  }, {
+    tableName: 'study_sessions',
+    underscored: true,
+    timestamps: false
+  });
+  return StudySession;
+};

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -24,7 +24,8 @@
         "passport-google-oauth20": "^2.0.0",
         "passport-kakao": "^1.0.1",
         "passport-local": "^1.0.0",
-        "sequelize": "^6.37.7"
+        "sequelize": "^6.37.7",
+        "vm2": "^3.9.19"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -235,6 +236,30 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -1921,6 +1946,23 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vm2": {
+      "version": "3.9.19",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.19.tgz",
+      "integrity": "sha512-J637XF0DHDMV57R6JyVsTak7nIL8gy5KH4r1HiwWLf/4GBbb5MKL5y7LpmF4A8E2nR6XmzpmMFQ7V7ppPTmUQg==",
+      "deprecated": "The library contains critical security issues and should not be used for production! The maintenance of the project has been discontinued. Consider migrating your code to isolated-vm.",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.7.0",
+        "acorn-walk": "^8.2.0"
+      },
+      "bin": {
+        "vm2": "bin/vm2"
+      },
+      "engines": {
+        "node": ">=6.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -28,6 +28,7 @@
     "passport-google-oauth20": "^2.0.0",
     "passport-kakao": "^1.0.1",
     "passport-local": "^1.0.0",
-    "sequelize": "^6.37.7"
+    "sequelize": "^6.37.7",
+    "vm2": "^3.9.19"
   }
 }

--- a/backend/routes/analytics.js
+++ b/backend/routes/analytics.js
@@ -1,0 +1,175 @@
+'use strict';
+
+const express = require('express');
+const router = express.Router();
+const db = require('../models');
+const { Op, Sequelize } = require('sequelize');
+
+/**
+ * POST /api/analytics/log
+ * body: {
+ *   handle, language, topic, level, source, problem_id,
+ *   started_at?, finished_at?, duration_ms?,
+ *   blanks_total, blanks_correct,
+ *   blanks_detail: [{id, user, answer, correct}]
+ * }
+ */
+router.post('/log', async (req, res) => {
+  try {
+    if (!db?.StudySession) return res.status(503).json({ error: 'db_unavailable' });
+
+    const {
+      handle = null, client_id = null, user_id = null, language, topic, level, source = 'bank', problem_id = null,
+      started_at = new Date(), finished_at = new Date(), duration_ms = null,
+      blanks_total, blanks_correct, blanks_detail
+    } = req.body || {};
+
+    // 로그인된 사용자의 경우 user_id 우선 사용
+    const finalUserId = user_id || (req.user ? req.user.user_id : null);
+    const finalHandle = handle || (req.user ? req.user.username : 'anonymous');
+
+    if ((!finalHandle && !client_id && !finalUserId) || !language || !topic || !level || !blanks_total || blanks_correct == null || !Array.isArray(blanks_detail)) {
+      return res.status(400).json({ error: 'bad_request', detail: 'need user_id/handle/client_id + required fields' });
+    }
+
+    const row = await db.StudySession.create({
+      user_id: finalUserId,
+      handle: finalHandle,
+      client_id, language, topic, level, source, problem_id,
+      started_at, finished_at, duration_ms,
+      blanks_total, blanks_correct, blanks_detail
+    });
+
+    res.json({ ok: true, id: row.id });
+  } catch (e) {
+    console.error('[analytics/log] error', e);
+    res.status(500).json({ error: 'internal_error', detail: String(e.message || e) });
+  }
+});
+
+/**
+ * GET /api/analytics/summary?handle=koosaga&from=2025-09-01&to=2025-09-30
+ * 반환: totals, perTopic, perLevel, recent
+ */
+router.get('/summary', async (req, res) => {
+  try {
+    if (!db?.StudySession) return res.status(503).json({ error: 'db_unavailable' });
+    const { handle = null, client_id = null, user_id = null } = req.query;
+    
+    // 로그인된 사용자의 경우 자동으로 user_id 사용
+    const finalUserId = user_id || (req.user ? req.user.user_id : null);
+    
+    if (!handle && !client_id && !finalUserId) {
+      return res.status(400).json({ error: 'bad_request', detail: 'user_id, handle or client_id required' });
+    }
+
+    const from = req.query.from ? new Date(String(req.query.from)) : new Date('1970-01-01');
+    const to   = req.query.to   ? new Date(String(req.query.to))   : new Date(Date.now() + 24*3600*1000);
+
+    const where = {
+      ...(finalUserId ? { user_id: finalUserId } : handle ? { handle } : { client_id }),
+      created_at: { [Op.between]: [from, to] }
+    };
+
+    // totals
+    const totals = await db.StudySession.findOne({
+      where,
+      attributes: [
+        [Sequelize.fn('COUNT', Sequelize.col('id')), 'sessions'],
+        [Sequelize.fn('AVG', Sequelize.col('accuracy')), 'avg_accuracy'],
+        [Sequelize.fn('AVG', Sequelize.col('duration_ms')), 'avg_duration_ms'],
+        [Sequelize.fn('SUM', Sequelize.col('blanks_total')), 'blanks_total'],
+        [Sequelize.fn('SUM', Sequelize.col('blanks_correct')), 'blanks_correct']
+      ],
+      raw: true
+    });
+
+    // per topic
+    const perTopic = await db.StudySession.findAll({
+      where,
+      attributes: [
+        'topic',
+        [Sequelize.fn('COUNT', Sequelize.col('id')), 'sessions'],
+        [Sequelize.fn('AVG', Sequelize.col('accuracy')), 'accuracy']
+      ],
+      group: ['topic'],
+      order: [[Sequelize.literal('accuracy'), 'ASC']],
+      raw: true
+    });
+
+    // per level
+    const perLevel = await db.StudySession.findAll({
+      where,
+      attributes: [
+        'level',
+        [Sequelize.fn('COUNT', Sequelize.col('id')), 'sessions'],
+        [Sequelize.fn('AVG', Sequelize.col('accuracy')), 'accuracy']
+      ],
+      group: ['level'],
+      order: [['level', 'ASC']],
+      raw: true
+    });
+
+    // 최근 10개
+    const recent = await db.StudySession.findAll({
+      where,
+      order: [['created_at', 'DESC']],
+      limit: 10
+    });
+
+    res.json({ totals, perTopic, perLevel, recent });
+  } catch (e) {
+    console.error('[analytics/summary] error', e);
+    res.status(500).json({ error: 'internal_error', detail: String(e.message || e) });
+  }
+});
+
+/**
+ * GET /api/analytics/timeseries?handle=koosaga&bucket=day&from=...&to=...
+ * day/week 버킷별 정확도/시도수
+ */
+router.get('/timeseries', async (req, res) => {
+  try {
+    if (!db?.StudySession) return res.status(503).json({ error: 'db_unavailable' });
+    const { handle = null, client_id = null, user_id = null } = req.query;
+    
+    // 로그인된 사용자의 경우 자동으로 user_id 사용
+    const finalUserId = user_id || (req.user ? req.user.user_id : null);
+    
+    if (!handle && !client_id && !finalUserId) {
+      return res.status(400).json({ error: 'bad_request', detail: 'user_id, handle or client_id required' });
+    }
+
+    const bucket = (req.query.bucket || 'day').toString().toLowerCase(); // day|week
+    const from = req.query.from ? new Date(String(req.query.from)) : new Date('1970-01-01');
+    const to   = req.query.to   ? new Date(String(req.query.to))   : new Date(Date.now() + 24*3600*1000);
+    
+    const keyCol = finalUserId ? 'user_id' : handle ? 'handle' : 'client_id';
+    const keyVal = finalUserId || handle || client_id;
+
+    // MySQL 8: DATE(created_at) or YEARWEEK(created_at)
+    const groupExpr = bucket === 'week' ? 'YEARWEEK(created_at, 3)' : 'DATE(created_at)';
+    const [rows] = await db.sequelize.query(
+      `
+      SELECT ${groupExpr} AS bucket,
+             COUNT(id) AS sessions,
+             AVG(accuracy) AS accuracy,
+             SUM(blanks_total) AS blanks_total,
+             SUM(blanks_correct) AS blanks_correct
+      FROM study_sessions
+      WHERE ${keyCol} = :keyVal
+        AND created_at BETWEEN :from AND :to
+      GROUP BY ${groupExpr}
+      ORDER BY ${groupExpr} ASC
+      `,
+      { replacements: { keyVal, from, to } }
+    );
+
+    res.json({ bucket, items: rows });
+  } catch (e) {
+    console.error('[analytics/timeseries] error', e);
+    res.status(500).json({ error: 'internal_error', detail: String(e.message || e) });
+  }
+});
+
+module.exports = router;

--- a/backend/routes/solve.js
+++ b/backend/routes/solve.js
@@ -1,0 +1,189 @@
+'use strict';
+
+const express = require('express');
+const router = express.Router();
+const db = require('../models');
+const { VM } = require('vm2'); // js-only sandboxes for editor mode
+
+// id 정상화: "__1__" → 1, "1" → 1
+const normId = (x) => {
+  const n = Number(String(x).replace(/\D/g, ''));
+  return Number.isFinite(n) && n > 0 ? n : 0;
+};
+
+// 문제의 정답 맵 {1: 'answer', 2:'...'}
+const buildAnswerMap = (blanks=[]) => {
+  const map = {};
+  blanks.forEach(b => {
+    const k = normId(b.id);
+    if (k) map[k] = (b.answer ?? '').trim();
+  });
+  return map;
+};
+
+/**
+ * POST /api/solve/grade
+ * body: {
+ *   mode: 'block' | 'cloze' | 'editor',
+ *   client_id?: string, handle?: string,
+ *   problem_id: number,
+ *   // block
+ *   block_tokens?: string[],      // 유저가 배치한 토큰(=정답 토큰들)
+ *   // cloze
+ *   blanks_user?: Array<{ id: number|string, value: string }>,
+ *   // editor
+ *   language?: string, code?: string
+ * }
+ */
+router.post('/grade', async (req, res) => {
+  try {
+    const mode = String(req.body?.mode || '').toLowerCase();
+    const problemId = Number(req.body?.problem_id || 0);
+    if (!mode || !problemId) {
+      return res.status(400).json({ error: 'bad_request', detail: 'mode and problem_id required' });
+    }
+    const prob = await db.ProblemBank.findByPk(problemId);
+    if (!prob) return res.status(404).json({ error: 'not_found', detail: 'problem not found' });
+
+    const answers = buildAnswerMap(prob.blanks || []);
+    const blanksTotal = Object.keys(answers).length;
+
+    let blanksCorrect = 0;
+    let feedback = {};
+    let extra = {};
+
+    if (mode === 'cloze') {
+      const user = Array.isArray(req.body?.blanks_user) ? req.body.blanks_user : [];
+      const resMap = {};
+      user.forEach(item => {
+        const k = normId(item.id);
+        const u = String(item.value ?? '').trim();
+        const a = (answers[k] ?? '').trim();
+        const ok = a.length>0 && u.length>0 && a === u;
+        if (ok) blanksCorrect++;
+        resMap[k] = { user: u, answer: a, correct: ok };
+      });
+      feedback = resMap;
+    }
+
+    else if (mode === 'block') {
+      // 가장 단순한 룰: 정답 토큰(answers)을 모두 포함하고 순서가 일치하면 정답.
+      // (레벨 0-1용. 향후 블록 DSL이나 블록 ID 기반 검사로 고도화 가능)
+      const tokens = Array.isArray(req.body?.block_tokens) ? req.body.block_tokens.map(s => String(s).trim()) : [];
+      const keyOrder = Object.keys(answers).map(Number).sort((a,b)=>a-b);
+      const expectedSeq = keyOrder.map(k => answers[k]);
+      const minLen = Math.min(tokens.length, expectedSeq.length);
+      for (let i=0;i<minLen;i++){
+        const ok = tokens[i] === expectedSeq[i];
+        if (ok) blanksCorrect++;
+        feedback[i+1] = { user: tokens[i], answer: expectedSeq[i], correct: ok };
+      }
+      extra.expected = expectedSeq;
+      extra.received = tokens;
+    }
+
+    else if (mode === 'editor') {
+      const lang = String(req.body?.language || 'javascript').toLowerCase();
+      const code = String(req.body?.code || '');
+      if (lang !== 'javascript') {
+        return res.status(400).json({ error: 'language_not_supported', detail: 'editor mode supports javascript only for now' });
+      }
+
+      // 문제 예시를 테스트로 사용: solve(input) -> output 비교
+      const examples = Array.isArray(prob.examples) ? prob.examples : [];
+      let passed = 0;
+      const results = [];
+      try {
+        // 샌드박스 준비
+        const vm = new VM({
+          timeout: 1000,
+          eval: false,
+          wasm: false,
+          sandbox: {}
+        });
+        // 유저 코드 + solve 함수 존재 확인
+        vm.run(`${code}\nif (typeof solve !== 'function') { throw new Error('solve function missing'); }`);
+
+        for (const ex of examples) {
+          // input 을 배열/단일로 파싱 시도 (간단한 규칙)
+          const argText = String(ex.input ?? '').trim();
+          let args;
+          try {
+            // "[1,2]" 또는 "1 2" 등 처리
+            if (/^\s*\[/.test(argText)) {
+              args = JSON.parse(argText);
+              if (!Array.isArray(args)) args = [args];
+            } else {
+              args = argText.length ? argText.split(/\s+/).map(x => isNaN(Number(x)) ? x : Number(x)) : [];
+            }
+          } catch { args = [argText]; }
+
+          const expected = String(ex.output ?? '').trim();
+          let got;
+          try {
+            got = vm.run(`solve.apply(null, ${JSON.stringify(args)})`);
+          } catch (err) {
+            results.push({ input: args, error: String(err?.message || err) });
+            continue;
+          }
+          const ok = String(got) === expected;
+          if (ok) passed++;
+          results.push({ input: args, output: String(got), expected, correct: ok });
+        }
+      } catch (e) {
+        return res.status(200).json({ ok: false, mode, problem_id: problemId, error: String(e.message || e) });
+      }
+      blanksCorrect = passed;
+      // blanksTotal 을 테스트 케이스 수로 간주
+      extra.tests = results;
+      // cloze와 형식을 맞추기 위해 feedback에 요약만
+      feedback = Object.fromEntries(results.map((r, i) => [i+1, { user: r.output, answer: r.expected, correct: !!r.correct }]));
+    }
+
+    else {
+      return res.status(400).json({ error: 'bad_request', detail: 'unknown mode' });
+    }
+
+    const accuracy = blanksTotal > 0 ? (blanksCorrect / blanksTotal) * 100 : 0;
+
+    // 학습 세션 로깅 (client_id/handle 둘 다 허용)
+    try {
+      const started = req.body?.started_at ? new Date(req.body.started_at) : new Date();
+      const finished = req.body?.finished_at ? new Date(req.body.finished_at) : new Date();
+      const duration = req.body?.duration_ms ?? (finished - started);
+      await db.StudySession.create({
+        handle: req.body?.handle || 'anonymous',
+        client_id: req.body?.client_id || null,
+        language: prob.language || 'python',
+        topic: prob.topic || 'unknown',
+        level: prob.level || 0,
+        source: 'bank',
+        problem_id: prob.id,
+        started_at: started,
+        finished_at: finished,
+        duration_ms: duration,
+        blanks_total: blanksTotal,
+        blanks_correct: blanksCorrect,
+        blanks_detail: feedback
+      });
+    } catch (e) {
+      console.warn('[solve/grade] log save failed:', e?.message || e);
+    }
+
+    res.json({
+      ok: true,
+      mode,
+      problem_id: problemId,
+      blanks_total: blanksTotal,
+      blanks_correct: blanksCorrect,
+      accuracy: Number(accuracy.toFixed(1)),
+      feedback,
+      ...extra
+    });
+  } catch (e) {
+    console.error('[solve/grade] error', e);
+    res.status(500).json({ error: 'internal_error', detail: String(e.message || e) });
+  }
+});
+
+module.exports = router;

--- a/backend/services/openaiProblemGen.js
+++ b/backend/services/openaiProblemGen.js
@@ -106,11 +106,31 @@ async function generateProblem({ level = 10, topic = 'graph', language = 'python
   let code = String(data.code_template || '');
   code = normalizePlaceholders(code, language, data.blanks.length);
   const phCount = countPlaceholders(code);
+  
+  // placeholder와 blanks 개수가 맞지 않을 때 조정
   if (phCount !== data.blanks.length) {
-    if (phCount === 0 && data.blanks.length > 0) {
-      let i = 1;
+    console.warn(`Placeholder count mismatch: placeholders(${phCount}) != blanks(${data.blanks.length})`);
+    
+    if (phCount > data.blanks.length) {
+      // placeholder가 더 많으면 blanks를 추가
+      const needed = phCount - data.blanks.length;
+      for (let i = 0; i < needed; i++) {
+        data.blanks.push({
+          id: data.blanks.length + i + 1,
+          answer: '???',
+          hint: 'Fill in the blank'
+        });
+      }
+    } else if (phCount < data.blanks.length) {
+      // blanks가 더 많으면 blanks를 줄임
+      data.blanks = data.blanks.slice(0, phCount);
     }
-    throw new Error(`placeholders(${phCount}) != blanks(${data.blanks.length})`);
+    
+    // 여전히 0개라면 최소 1개는 만들기
+    if (phCount === 0 && data.blanks.length === 0) {
+      code = code + '\n# __1__ # Complete this line';
+      data.blanks = [{ id: 1, answer: 'pass', hint: 'Complete the implementation' }];
+    }
   }
 
   return {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,9 +11,11 @@
       "dependencies": {
         "bootstrap": "^5.3.8",
         "bootstrap-icons": "^1.13.1",
+        "date-fns": "^4.1.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.28.0"
+        "react-router-dom": "^6.28.0",
+        "recharts": "^3.2.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.2",
@@ -813,6 +815,32 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.9.0.tgz",
+      "integrity": "sha512-fSfQlSRu9Z5yBkvsNhYF2rPS8cGXn/TZVrlwN1948QyZ8xMZ0JvP50S2acZNaf+o63u6aEeMjipFyksjIcWrog==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
@@ -1108,6 +1136,18 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1153,6 +1193,69 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1180,13 +1283,13 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1223,6 +1326,12 @@
         "@types/react": "*",
         "@types/react-router": "*"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.6.0",
@@ -1334,6 +1443,15 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1345,8 +1463,139 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -1366,12 +1615,28 @@
         }
       }
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.182",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.182.tgz",
       "integrity": "sha512-Lv65Btwv9W4J9pyODI6EWpdnhfvrve/us5h1WspW8B2Fb0366REPtY3hX7ounk1CkV/TBjWCEvCBBbYbmV0qCA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.39.10",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.10.tgz",
+      "integrity": "sha512-E0iGnTtbDhkeczB0T+mxmoVlT4YNweEKBLq7oaU4p11mecdsZpNWOglI4895Vh4usbQ+LsJiuLuI2L0Vdmfm2w==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.25.6",
@@ -1425,6 +1690,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.4.6",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
@@ -1463,6 +1734,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.3.tgz",
+      "integrity": "sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/js-tokens": {
@@ -1623,6 +1913,36 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz",
+      "integrity": "sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -1662,6 +1982,54 @@
         "react": ">=16.8",
         "react-dom": ">=16.8"
       }
+    },
+    "node_modules/recharts": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.2.0.tgz",
+      "integrity": "sha512-fX0xCgNXo6mag9wz3oLuANR+dUQM4uIlTYBGTGq9CBRgW/8TZPzqPGYs5NTt8aENCf+i1CI8vqxT1py8L/5J2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.45.0",
@@ -1731,6 +2099,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -1797,6 +2171,37 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,9 +16,11 @@
   "dependencies": {
     "bootstrap": "^5.3.8",
     "bootstrap-icons": "^1.13.1",
+    "date-fns": "^4.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.28.0"
+    "react-router-dom": "^6.28.0",
+    "recharts": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,14 +1,16 @@
-import { Routes, Route } from 'react-router-dom'
-import { AuthProvider } from './contexts/AuthContext'
-import Navbar from './components/Navbar'
-import HomePage from './pages/HomePage'
-import LoginPage from './pages/LoginPage'
-import SignupPage from './pages/SignupPage'
-import ProfilePage from './pages/ProfilePage'
-import SurveyPage from './pages/SurveyPage'
-import LevelTestPage from './pages/LevelTestPage'
-import ProblemsPage from './pages/ProblemsPage'
-import QuizPage from './pages/QuizPage'
+import { Routes, Route } from "react-router-dom";
+import { AuthProvider } from "./contexts/AuthContext";
+import Navbar from "./components/Navbar";
+import HomePage from "./pages/HomePage";
+import LoginPage from "./pages/LoginPage";
+import SignupPage from "./pages/SignupPage";
+import ProfilePage from "./pages/ProfilePage";
+import SurveyPage from "./pages/SurveyPage";
+import LevelTestPage from "./pages/LevelTestPage";
+import ProblemsPage from "./pages/ProblemsPage";
+import QuizPage from "./pages/QuizPage";
+import DashboardPage from "./pages/DashboardPage";
+import SolvePage from "./pages/SolvePage";
 
 function App() {
   return (
@@ -26,11 +28,13 @@ function App() {
             <Route path="/level-test" element={<LevelTestPage />} />
             <Route path="/problems" element={<ProblemsPage />} />
             <Route path="/quiz" element={<QuizPage />} />
+            <Route path="/dashboard" element={<DashboardPage />} />
+            <Route path="/solve" element={<SolvePage />} />
           </Routes>
         </main>
       </div>
     </AuthProvider>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -53,6 +53,23 @@ const Navbar = () => {
               </Link>
             </li>
             
+            {isAuthenticated && (
+              <>
+                <li className="nav-item">
+                  <Link className="nav-link" to="/quiz">
+                    <i className="bi bi-code-slash me-1"></i>
+                    알고리즘 퀴즈
+                  </Link>
+                </li>
+                <li className="nav-item">
+                  <Link className="nav-link" to="/dashboard">
+                    <i className="bi bi-graph-up me-1"></i>
+                    학습 통계
+                  </Link>
+                </li>
+              </>
+            )}
+            
             {isAuthenticated ? (
               <>
                 <li className="nav-item dropdown">

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+} from "recharts";
+import { useAuth } from "../contexts/AuthContext";
+import { CLIENT_ID } from "../utils/clientId";
+import { ApiErrorHandler, numericHelpers } from "../utils/apiHelpers";
+import type { AnalyticsSummary, TimeSeriesData } from "../types/api";
+
+// 타입은 별도 파일에서 import
+
+export default function DashboardPage() {
+  const { user, isAuthenticated } = useAuth();
+  const navigate = useNavigate();
+
+  // 인증되지 않은 사용자는 로그인 페이지로 리다이렉트
+  if (!isAuthenticated) {
+    navigate('/login');
+    return (
+      <div className="max-w-5xl mx-auto p-4 text-center">
+        <h1 className="text-2xl font-bold text-gray-600">로그인이 필요합니다</h1>
+        <p className="mt-2 text-gray-500">잠시 후 로그인 페이지로 이동합니다...</p>
+      </div>
+    );
+  }
+
+  const [summary, setSummary] = useState<AnalyticsSummary>({});
+  const [series, setSeries] = useState<TimeSeriesData["items"]>([]);
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState("");
+
+  const load = async () => {
+    try {
+      setLoading(true);
+      setErr("");
+
+      // 요약 데이터 가져오기 (로그인된 사용자 기반)
+      const summaryResponse = await fetch(
+        `/api/analytics/summary`, // user_id는 백엔드에서 자동으로 처리
+        {
+          method: "GET",
+          credentials: "include", // 세션 쿠키 포함
+        }
+      );
+      const summaryData =
+        await ApiErrorHandler.handleResponse<AnalyticsSummary>(summaryResponse);
+      setSummary(summaryData);
+
+      // 시계열 데이터 가져오기 (로그인된 사용자 기반)
+      const timeseriesResponse = await fetch(
+        `/api/analytics/timeseries?bucket=day`, // user_id는 백엔드에서 자동으로 처리
+        {
+          method: "GET",
+          credentials: "include", // 세션 쿠키 포함
+        }
+      );
+      const timeseriesData =
+        await ApiErrorHandler.handleResponse<TimeSeriesData>(
+          timeseriesResponse
+        );
+      setSeries(
+        (timeseriesData.items || []).map((r) => ({
+          bucket: String(r.bucket),
+          sessions: numericHelpers.toNumber(r.sessions),
+          accuracy: numericHelpers.toNumber(r.accuracy),
+        }))
+      );
+    } catch (error) {
+      setErr(ApiErrorHandler.formatError(error));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const topicData = useMemo(
+    () =>
+      (summary.perTopic || []).map((r) => ({
+        ...r,
+        accuracy: numericHelpers.toNumber(r.accuracy),
+        sessions: numericHelpers.toNumber(r.sessions),
+      })),
+    [summary.perTopic]
+  );
+
+  useEffect(() => {
+    load();
+  }, []); // 첫 진입시 자동 로딩
+
+  return (
+    <div className="max-w-5xl mx-auto p-4">
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-2xl font-bold">학습 통계 대시보드</h1>
+        <div className="text-sm text-gray-600">
+          <span className="font-semibold text-blue-600">{user?.username}</span>님의 학습 통계
+        </div>
+      </div>
+
+      <div className="mt-2">
+        <button
+          onClick={load}
+          disabled={loading}
+          className="h-9 border rounded px-3 font-semibold hover:bg-gray-50 disabled:opacity-60"
+        >
+          {loading ? "불러오는 중..." : "새로고침"}
+        </button>
+        <span className="ml-3 text-xs text-gray-500">
+          사용자 ID: {user?.id} | 백업 Client: {CLIENT_ID}
+        </span>
+      </div>
+
+      {err && (
+        <div className="mt-3 text-sm text-red-600 whitespace-pre-wrap">
+          에러: {err}
+        </div>
+      )}
+
+      {/* 핵심 지표 */}
+      <section className="mt-6">
+        <h2 className="text-xl font-bold mb-2">핵심 지표</h2>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          <Card
+            title="세션 수"
+            value={numericHelpers.toNumber(summary.totals?.sessions)}
+          />
+          <Card
+            title="평균 정확도(%)"
+            value={numericHelpers.toFixed(summary.totals?.avg_accuracy, 1)}
+          />
+          <Card
+            title="평균 소요(ms)"
+            value={Math.round(
+              numericHelpers.toNumber(summary.totals?.avg_duration_ms)
+            )}
+          />
+          <Card
+            title="정답/전체(blank)"
+            value={`${numericHelpers.toNumber(summary.totals?.blanks_correct)}/${numericHelpers.toNumber(summary.totals?.blanks_total)}`}
+          />
+        </div>
+      </section>
+
+      {/* 정확도 추이(일별) */}
+      <section className="mt-6">
+        <h2 className="text-xl font-bold mb-2">정확도 추이(일별)</h2>
+        <div className="h-64 border rounded">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={series}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="bucket" />
+              <YAxis domain={[0, 100]} />
+              <Tooltip />
+              <Line
+                type="monotone"
+                dataKey="accuracy"
+                stroke="#8884d8"
+                dot={false}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </section>
+
+      {/* 약점 진단(주제별 정확도) */}
+      <section className="mt-6">
+        <h2 className="text-xl font-bold mb-2">약점 진단(주제별 정확도)</h2>
+        <div className="h-64 border rounded">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={topicData.slice(0, 8)}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="topic" />
+              <YAxis domain={[0, 100]} />
+              <Tooltip />
+              <Bar dataKey="accuracy" fill="#82ca9d" />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function Card({ title, value }: { title: string; value: any }) {
+  return (
+    <div className="border rounded p-3">
+      <div className="text-sm text-gray-600">{title}</div>
+      <div className="text-xl font-bold">{String(value)}</div>
+    </div>
+  );
+}

--- a/frontend/src/pages/SolvePage.tsx
+++ b/frontend/src/pages/SolvePage.tsx
@@ -1,0 +1,477 @@
+import { useMemo, useState } from "react";
+
+// ===== client id =====
+const getClientId = (): string => {
+  const KEY = "gpters.clientId";
+  const stored =
+    typeof localStorage !== "undefined" ? localStorage.getItem(KEY) : null;
+  if (stored) return stored;
+
+  const rand = (n = 8) =>
+    Math.random()
+      .toString(36)
+      .slice(2, 2 + n);
+  // globalThis.crypto?.randomUUID() 가 있으면 사용, 없으면 fallback
+  const newId =
+    (typeof globalThis !== "undefined" &&
+      (globalThis as any).crypto?.randomUUID?.()) ||
+    `${rand(6)}-${Date.now().toString(36)}-${rand(6)}`;
+
+  if (typeof localStorage !== "undefined") {
+    localStorage.setItem(KEY, newId); // newId는 string 확정
+  }
+  return newId;
+};
+
+const CLIENT_ID = getClientId();
+
+// ===== code view helpers (same as QuizPage) =====
+const escapeHtml = (s: string) =>
+  String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+const stripCommentedPlaceholders = (escaped: string): string => {
+  if (!escaped) return "";
+  let out = escaped.replace(
+    /(^|[\r\n])([ \t]*)#\s*__\s*(\d+)\s*__/g,
+    (_m: string, a: string, indent: string, d: string): string =>
+      `${a}${indent}__${d}__`
+  );
+  out = out.replace(
+    /\/\*\s*__\s*(\d+)\s*__\s*\*\//g,
+    (_m: string, d: string): string => `__${d}__`
+  );
+  out = out.replace(
+    /\/\/\s*__\s*(\d+)\s*__/g,
+    (_m: string, d: string): string => `__${d}__`
+  );
+  return out;
+};
+const emphasizePlaceholders = (code: string) => {
+  const escaped = escapeHtml(code);
+  const noComments = stripCommentedPlaceholders(escaped);
+  return noComments.replace(
+    /__\s*(\d+)\s*__/g,
+    (_m, d) =>
+      `<mark class="px-1 rounded bg-yellow-500/30 text-yellow-200 font-semibold">__${d}__</mark>`
+  );
+};
+
+// ===== types =====
+type Blank = { id: number | string; hint?: string; answer?: string };
+type Example = { input: string; output: string; explanation?: string };
+type Problem = {
+  id?: number;
+  title: string;
+  statement?: string;
+  input_spec?: string;
+  output_spec?: string;
+  constraints?: string;
+  examples?: Example[];
+  code: string;
+  blanks: Blank[];
+  level?: number;
+  topic?: string;
+  language?: string;
+};
+
+export default function SolvePage() {
+  const [uiLevel, setUiLevel] = useState<number>(2); // 0-5
+  const [language, setLanguage] = useState<string>("javascript"); // editor용
+  const [problem, setProblem] = useState<Problem | null>(null);
+  const [err, setErr] = useState<string>("");
+  const [loading, setLoading] = useState<boolean>(false);
+
+  // 클로즈/블록 공통
+  const orderedBlanks = useMemo<Blank[]>(() => {
+    const arr = (problem?.blanks ?? []).map((b) => {
+      const n = Number(String(b.id).replace(/\D/g, ""));
+      return { ...b, id: Number.isFinite(n) && n > 0 ? n : 1 };
+    });
+    arr.sort((a: any, b: any) => Number(a.id) - Number(b.id));
+    return arr;
+  }, [problem]);
+
+  // 블록 모드 상태(토큰 박스)
+  const [blockTokens, setBlockTokens] = useState<string[]>([]);
+  // 클로즈 입력
+  const [fills, setFills] = useState<string[]>([]);
+  // 에디터 코드
+  const [editorCode, setEditorCode] = useState<string>(
+    "function solve(){\n  // TODO: implement\n  return 0;\n}"
+  );
+
+  // 로딩: 문제 생성 (랜덤)
+  const fetchProblem = async () => {
+    try {
+      setLoading(true);
+      setErr("");
+      const topics = ["graph", "dp", "greedy", "tree", "string", "math"];
+      const pick = <T,>(a: T[]) => a[Math.floor(Math.random() * a.length)];
+      const params = {
+        level: 25 + Math.floor(Math.random() * 6),
+        topic: pick(topics),
+        language: "python",
+      };
+
+      const res = await fetch("/api/problem-bank/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(params),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      const j: Problem = await res.json();
+      setProblem(j);
+      setFills(Array((j.blanks ?? []).length).fill(""));
+      // 블록 모드: 정답 토큰 셔플
+      const tokens = (j.blanks ?? [])
+        .map((b) => (b as any).answer ?? "")
+        .filter(Boolean);
+      setBlockTokens(shuffle(tokens));
+    } catch (e: any) {
+      setErr(String(e?.message || e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const shuffle = (arr: string[]) => {
+    const a = arr.slice();
+    for (let i = a.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [a[i], a[j]] = [a[j], a[i]];
+    }
+    return a;
+  };
+
+  const submitBlock = async () => {
+    if (!problem) return;
+    const started_at = new Date().toISOString();
+    const finished_at = new Date().toISOString();
+    const body = {
+      mode: "block",
+      client_id: CLIENT_ID,
+      problem_id: problem.id,
+      block_tokens: blockTokens,
+      started_at,
+      finished_at,
+    };
+    const r = await fetch("/api/solve/grade", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const j = await r.json();
+    alert(JSON.stringify(j, null, 2));
+  };
+
+  const submitCloze = async () => {
+    if (!problem) return;
+    const blanks_user = orderedBlanks.map((b, i) => ({
+      id: b.id,
+      value: fills[i] ?? "",
+    }));
+    const body = {
+      mode: "cloze",
+      client_id: CLIENT_ID,
+      problem_id: problem.id,
+      blanks_user,
+      started_at: new Date().toISOString(),
+      finished_at: new Date().toISOString(),
+    };
+    const r = await fetch("/api/solve/grade", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const j = await r.json();
+    alert(JSON.stringify(j, null, 2));
+  };
+
+  const submitEditor = async () => {
+    if (!problem) return;
+    const body = {
+      mode: "editor",
+      client_id: CLIENT_ID,
+      problem_id: problem.id,
+      language,
+      code: editorCode,
+      started_at: new Date().toISOString(),
+      finished_at: new Date().toISOString(),
+    };
+    const r = await fetch("/api/solve/grade", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const j = await r.json();
+    alert(JSON.stringify(j, null, 2));
+  };
+
+  return (
+    <div className="max-w-5xl mx-auto p-4">
+      <h1 className="text-2xl font-bold">레벨별 문제 해결</h1>
+
+      {/* 상단 컨트롤 */}
+      <div className="mt-4 grid grid-cols-1 md:grid-cols-6 gap-3 items-end">
+        <div className="col-span-2">
+          <label className="block text-sm text-gray-600">UI Level (0~5)</label>
+          <input
+            type="range"
+            min={0}
+            max={5}
+            value={uiLevel}
+            onChange={(e) => setUiLevel(Number(e.target.value))}
+            className="w-full"
+          />
+          <div className="text-xs text-gray-500 mt-1">
+            0-1: 블록 / 2-3: 빈칸 / 4-5: 에디터
+          </div>
+        </div>
+        <div>
+          <label className="block text-sm text-gray-600">Editor Language</label>
+          <select
+            value={language}
+            onChange={(e) => setLanguage(e.target.value)}
+            className="w-full border rounded px-2 py-1"
+          >
+            <option value="javascript">javascript</option>
+            <option value="python" disabled>
+              python (미지원)
+            </option>
+            <option value="cpp" disabled>
+              cpp (미지원)
+            </option>
+          </select>
+        </div>
+        <button
+          onClick={fetchProblem}
+          disabled={loading}
+          className="h-9 border rounded px-3 font-semibold hover:bg-gray-50"
+        >
+          {loading ? "불러오는 중..." : "문제 생성"}
+        </button>
+      </div>
+
+      {err && (
+        <div className="mt-3 text-sm text-red-600 whitespace-pre-wrap">
+          에러: {err}
+        </div>
+      )}
+
+      {/* 문제 본문 */}
+      {problem && (
+        <section className="mt-6">
+          <h2 className="text-xl font-bold mb-2">문제 전문</h2>
+          <div className="border rounded p-3 whitespace-pre-wrap">
+            <div className="font-semibold mb-2">[{problem.title}]</div>
+            <div className="mb-3">
+              {problem.statement || (
+                <span className="text-gray-500">문제 설명 없음</span>
+              )}
+            </div>
+            {(problem.input_spec || problem.output_spec) && (
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                <div className="border rounded p-2">
+                  <div className="text-sm font-semibold mb-1">입력 형식</div>
+                  <div className="text-sm whitespace-pre-wrap">
+                    {problem.input_spec ?? "-"}
+                  </div>
+                </div>
+                <div className="border rounded p-2">
+                  <div className="text-sm font-semibold mb-1">출력 형식</div>
+                  <div className="text-sm whitespace-pre-wrap">
+                    {problem.output_spec ?? "-"}
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        </section>
+      )}
+
+      {/* 모드별 UI */}
+      {problem && (
+        <div className="mt-6 space-y-6">
+          {/* ===== 0-1: 블록(토큰 드래그-드롭) ===== */}
+          {uiLevel <= 1 && (
+            <section>
+              <h2 className="text-xl font-bold mb-2">블록 코딩(초급)</h2>
+              <p className="text-sm text-gray-600 mb-2">
+                정답 토큰을 올바른 순서로 정렬하세요.
+              </p>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                {/* 코드 미리보기 */}
+                <div>
+                  <div className="text-sm font-semibold mb-1">코드</div>
+                  {(() => {
+                    const html = emphasizePlaceholders(problem.code || "");
+                    return (
+                      <pre className="rounded-lg p-3 overflow-auto text-[13px] leading-6 bg-black text-white">
+                        <code
+                          className="font-mono whitespace-pre"
+                          dangerouslySetInnerHTML={{ __html: html }}
+                        />
+                      </pre>
+                    );
+                  })()}
+                  <div className="mt-2 text-sm text-gray-600">힌트:</div>
+                  <ol className="list-decimal ml-5 text-sm">
+                    {orderedBlanks.map((b: any) => (
+                      <li key={String(b.id)}>{b.hint || "(힌트 없음)"}</li>
+                    ))}
+                  </ol>
+                </div>
+
+                {/* 드래그 영역 */}
+                <BlockDnD tokens={blockTokens} setTokens={setBlockTokens} />
+              </div>
+
+              <div className="mt-3">
+                <button
+                  onClick={submitBlock}
+                  className="border rounded px-3 py-1 font-semibold hover:bg-gray-50"
+                >
+                  제출
+                </button>
+              </div>
+            </section>
+          )}
+
+          {/* ===== 2-3: 빈칸 채우기 ===== */}
+          {uiLevel >= 2 && uiLevel <= 3 && (
+            <section>
+              <h2 className="text-xl font-bold mb-2">빈칸 채우기</h2>
+              {(() => {
+                const html = emphasizePlaceholders(problem.code || "");
+                return (
+                  <pre className="rounded-lg p-3 overflow-auto text-[13px] leading-6 bg-black text-white">
+                    <code
+                      className="font-mono whitespace-pre"
+                      dangerouslySetInnerHTML={{ __html: html }}
+                    />
+                  </pre>
+                );
+              })()}
+              <div className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-2">
+                {orderedBlanks.map((b: any, i: number) => (
+                  <div key={String(b.id)} className="flex items-center gap-2">
+                    <label className="text-sm w-20">빈칸 {b.id}</label>
+                    <input
+                      className="flex-1 border rounded px-2 py-1 text-sm"
+                      value={fills[i] ?? ""}
+                      onChange={(e) =>
+                        setFills((p) => {
+                          const n = p.slice();
+                          n[i] = e.target.value;
+                          return n;
+                        })
+                      }
+                      placeholder="정답 입력"
+                    />
+                  </div>
+                ))}
+              </div>
+              <div className="mt-3">
+                <button
+                  onClick={submitCloze}
+                  className="border rounded px-3 py-1 font-semibold hover:bg-gray-50"
+                >
+                  제출
+                </button>
+              </div>
+            </section>
+          )}
+
+          {/* ===== 4-5: 코드 에디터(JS) ===== */}
+          {uiLevel >= 4 && (
+            <section>
+              <h2 className="text-xl font-bold mb-2">코드 에디터</h2>
+              <p className="text-sm text-gray-600 mb-2">
+                현재는 JavaScript만 채점합니다.{" "}
+                <code>function solve(...) {/* ... */}</code> 를 구현하세요.
+              </p>
+              <textarea
+                value={editorCode}
+                onChange={(e) => setEditorCode(e.target.value)}
+                className="w-full h-64 border rounded p-2 font-mono text-sm"
+              />
+              <div className="mt-3">
+                <button
+                  onClick={submitEditor}
+                  className="border rounded px-3 py-1 font-semibold hover:bg-gray-50"
+                >
+                  제출
+                </button>
+              </div>
+              {/* 예시 표시 */}
+              {Array.isArray(problem.examples) &&
+                problem.examples.length > 0 && (
+                  <div className="mt-3 text-sm">
+                    <div className="font-semibold">테스트 예시</div>
+                    <ul className="list-disc ml-5">
+                      {problem.examples.map((ex, idx) => (
+                        <li key={idx}>
+                          <b>input:</b> {ex.input} <b>→ expected:</b>{" "}
+                          {ex.output}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+            </section>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** 간단 드래그-드롭 정렬 컴포넌트 (레벨 0-1용) */
+function BlockDnD({
+  tokens,
+  setTokens,
+}: {
+  tokens: string[];
+  setTokens: (t: string[]) => void;
+}) {
+  const onDragStart = (e: React.DragEvent<HTMLDivElement>, idx: number) => {
+    e.dataTransfer.setData("text/plain", String(idx));
+  };
+  const onDrop = (e: React.DragEvent<HTMLDivElement>, idx: number) => {
+    const from = Number(e.dataTransfer.getData("text/plain"));
+    if (!Number.isFinite(from)) return;
+    const a = tokens.slice();
+    const [moved] = a.splice(from, 1);
+    a.splice(idx, 0, moved);
+    setTokens(a);
+  };
+  const onDragOver = (e: React.DragEvent<HTMLDivElement>) => e.preventDefault();
+
+  return (
+    <div>
+      <div className="text-sm font-semibold mb-1">토큰 순서</div>
+      <div className="border rounded p-2 min-h-12">
+        {tokens.length === 0 ? (
+          <div className="text-sm text-gray-500">토큰이 없습니다.</div>
+        ) : (
+          <div className="flex flex-wrap gap-2">
+            {tokens.map((t, i) => (
+              <div
+                key={i}
+                draggable
+                onDragStart={(e) => onDragStart(e, i)}
+                onDragOver={onDragOver}
+                onDrop={(e) => onDrop(e, i)}
+                className="cursor-move select-none bg-indigo-50 border border-indigo-200 px-2 py-1 rounded text-xs"
+              >
+                {t}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+      <div className="text-xs text-gray-500 mt-1">
+        드래그해서 순서를 맞춘 뒤 제출하세요.
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,0 +1,93 @@
+// API 응답 타입 정의
+
+// 공통 에러 응답
+export interface ApiError {
+  error: string;
+  detail?: string;
+}
+
+// 미세해서 정의
+
+export interface Example {
+  input: string;
+  output: string;
+  explanation?: string;
+}
+
+export interface Blank {
+  id: number;
+  hint?: string;
+  answer?: string;
+}
+
+export interface GeneratedProblem {
+  id?: number;
+  title: string;
+  statement?: string;
+  input_spec?: string;
+  output_spec?: string;
+  constraints?: string;
+  examples?: Example[];
+  code: string;
+  blanks: Blank[];
+  level?: number;
+  topic?: string;
+  language?: string;
+}
+
+// 대시보드 통계 데이터
+export interface AnalyticsSummary {
+  totals?: {
+    sessions?: number;
+    avg_accuracy?: number;
+    avg_duration_ms?: number;
+    blanks_total?: number;
+    blanks_correct?: number;
+  };
+  perTopic?: Array<{
+    topic: string;
+    sessions: number;
+    accuracy: number;
+  }>;
+  perLevel?: Array<{
+    level: number;
+    sessions: number;
+    accuracy: number;
+  }>;
+  recent?: any[];
+}
+
+export interface TimeSeriesData {
+  bucket: string;
+  items: Array<{
+    bucket: string;
+    sessions: number;
+    accuracy: number;
+    blanks_total?: number;
+    blanks_correct?: number;
+  }>;
+}
+
+// 학습 로그 데이터
+export interface StudyLogData {
+  user_id?: string; // 로그인된 사용자 ID
+  client_id?: string; // 비로그인 사용자용 클라이언트 ID
+  language: string;
+  topic: string;
+  level: number;
+  source: string;
+  problem_id?: number;
+  started_at?: string;
+  finished_at: string;
+  duration_ms?: number;
+  blanks_total: number;
+  blanks_correct: number;
+  blanks_detail: Array<{
+    id: number;
+    user: string;
+    answer: string;
+    correct: boolean;
+  }>;
+}
+
+

--- a/frontend/src/utils/apiHelpers.ts
+++ b/frontend/src/utils/apiHelpers.ts
@@ -1,0 +1,44 @@
+import type { ApiError } from '../types/api';
+
+// API 에러 처리 유틸리티
+export class ApiErrorHandler {
+  static async handleResponse<T>(response: Response): Promise<T> {
+    if (!response.ok) {
+      let errorMessage = `HTTP ${response.status}`;
+      
+      try {
+        const errorData: ApiError = await response.json();
+        errorMessage = errorData.detail || errorData.error || errorMessage;
+      } catch {
+        // JSON 파싱 실패 시 기본 메시지 사용
+        const text = await response.text().catch(() => '');
+        errorMessage = text || errorMessage;
+      }
+      
+      throw new Error(errorMessage);
+    }
+    
+    return response.json();
+  }
+  
+  static formatError(error: unknown): string {
+    if (error instanceof Error) {
+      return error.message;
+    }
+    return String(error || '알 수 없는 오류가 발생했습니다');
+  }
+}
+
+// 숫자 변환 헬퍼
+export const numericHelpers = {
+  toNumber: (value: any): number => {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : 0;
+  },
+  
+  toFixed: (value: any, decimals = 1): string => {
+    return numericHelpers.toNumber(value).toFixed(decimals);
+  }
+};
+
+

--- a/frontend/src/utils/clientId.ts
+++ b/frontend/src/utils/clientId.ts
@@ -1,0 +1,21 @@
+// 클라이언트 ID 관리 유틸리티
+export const getClientId = (): string => {
+  const KEY = "gpters.clientId";
+  let id = localStorage.getItem(KEY);
+  if (!id) {
+    // 간단 UUID 생성
+    const rand = (n = 8) =>
+      Math.random()
+        .toString(36)
+        .slice(2, 2 + n);
+    id =
+      (crypto as any)?.randomUUID?.() ||
+      `${rand(6)}-${Date.now().toString(36)}-${rand(6)}`;
+    localStorage.setItem(KEY, id);
+  }
+  return id;
+};
+
+export const CLIENT_ID = getClientId();
+
+


### PR DESCRIPTION
- QuizPage: 랜덤 문제 생성 기본값, 검은 배경/흰 글자 코드, 빈칸 하이라이트/주석 제거, 채점 시 client_id 로깅
- DashboardPage: 핸들 입력 없이 client_id 자동 집계, 안전 숫자 변환 적용
- SolvePage: 0-1 블록(토큰 정렬), 2-3 빈칸, 4-5 코드에디터(JS) 모드 추가

backend:
- /api/solve/grade 라우트 추가(cloze/block/editor(js, vm2 sandbox))
- analytics: handle 또는 client_id 지원(요약/시계열)
- study_sessions 모델 client_id 필드 지원"